### PR TITLE
bind onError to this

### DIFF
--- a/realtime-client-utils.js
+++ b/realtime-client-utils.js
@@ -151,7 +151,7 @@ utils.RealtimeUtils.prototype = {
     window.gapi.drive.realtime.load(documentId, function(doc) {
       window.doc = doc;  // Debugging purposes
       onFileLoaded(doc);
-    }, initializeModel, this.onError);
+    }, initializeModel, this.onError.bind(this));
   },
 
   /**


### PR DESCRIPTION
When token refresh is required, `onError` used to crash trying to access `this.authorizer.authorize`.
